### PR TITLE
Update instance name from `dandi` to `lincbrain`

### DIFF
--- a/lincbrain/consts.py
+++ b/lincbrain/consts.py
@@ -121,8 +121,8 @@ instancehost = os.environ.get("DANDI_INSTANCEHOST", "localhost")
 # TODO: Also add docs for what each of these values should map to
 
 known_instances = {
-    "dandi": DandiInstance(
-        "dandi",
+    "lincbrain": DandiInstance(
+        "lincbrain",
         "https://lincbrain.org",
         "https://api.lincbrain.org/api",
     ),

--- a/lincbrain/delete.py
+++ b/lincbrain/delete.py
@@ -192,7 +192,7 @@ class Deleter:
 
 def delete(
     paths: Iterable[str],
-    dandi_instance: str | DandiInstance = "dandi",
+    dandi_instance: str | DandiInstance = "lincbrain",
     devel_debug: bool = False,
     jobs: int | None = None,
     force: bool = False,

--- a/lincbrain/move.py
+++ b/lincbrain/move.py
@@ -789,7 +789,7 @@ def move(
     dest: str,
     regex: bool = False,
     existing: MoveExisting = MoveExisting.ERROR,
-    dandi_instance: str | DandiInstance = "dandi",
+    dandi_instance: str | DandiInstance = "lincbrain",
     dandiset: Path | str | None = None,
     work_on: MoveWorkOn = MoveWorkOn.AUTO,
     devel_debug: bool = False,

--- a/lincbrain/upload.py
+++ b/lincbrain/upload.py
@@ -70,7 +70,7 @@ def upload(
     paths: Sequence[str | Path] | None = None,
     existing: UploadExisting = UploadExisting.REFRESH,
     validation: UploadValidation = UploadValidation.REQUIRE,
-    dandi_instance: str | DandiInstance = "dandi",
+    dandi_instance: str | DandiInstance = "lincbrain",
     allow_any_path: bool = False,
     upload_dandiset_metadata: bool = False,
     devel_debug: bool = False,


### PR DESCRIPTION
With DANDI Archive there are several [resource identifiers](https://dandi.readthedocs.io/en/latest/ref/urls.html#resource-ids) which can be used to download an asset and/or Dandiset.  For the `--preserve-tree` option to work ideally, we need to use the resource identifier shown in the command below (or a similar variant that contains the instance name).  However, I receive an error when running the command below with version `0.11.1`.

Command
```
lincbrain download --preserve-tree dandi://LINCBRAIN/000724@draft/derivatives/dwi/sub-I58/sub-I58_sample-blockIC1_desc-preproc_dwi.bvals
```

Error
```
2024-08-07 11:14:37,968 [    INFO] Logs saved in /Users/kabilar/Library/Logs/lincbrain-cli/2024.08.07-16.14.37Z-98568.log
Error: Unknown instance 'lincbrain'.  Valid instances: dandi, dandi-api-local-docker-tests, lincbrain-staging
```

Should we also update or disable the other URL patterns in [_dandi_url_parser](https://github.com/lincbrain/linc-cli/blob/d682859bc5685217fbca5dd64525fe4189411d91/lincbrain/dandiarchive.py#L566) that contain `DANDI:`?

Thank you.